### PR TITLE
feat: support UNC path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,60 @@ Adds a button at the top of files in both Sourcegraph app and code hosts like Gi
 
 ## Configuration
 
-Set `vscode.open.basePath` in your user settings to a local folder that contains your Git repositories.
+- Set `vscode.open.basePath` in your user settings to a local folder that contains your Git repositories.
 The extension will try to open the file in a clone named by the last segment of the repository name in that folder.
+
+- Set `vscode.open.uncPath` to true in your user settings to enable support for UNC (Universal Naming Convention) paths.
+
+## Examples
+
+### Mac
+
+To open repository files in your Documents directory:
+
+```json
+{
+  "extensions": {
+    "sourcegraph/open-in-vscode": true
+  },
+  "vscode.open.basePath": "/Users/USERNAME/Documents/"
+}
+```
+
+### Windows
+
+To open repository files in your Documents directory:
+
+```json
+{
+  "extensions": {
+    "sourcegraph/open-in-vscode": true
+  },
+  "vscode.open.basePath": "/Users/USERNAME/Documents/"
+}
+```
+
+You may also use an absolute file path from the root of drive C: with the following setting:
+
+```json
+{
+  "extensions": {
+    "sourcegraph/open-in-vscode": true,
+  },
+  "vscode.open.basePath": "/C:/Users/USERNAME/Documents/"
+}
+```
+
+### WSL
+
+To open repository files in your Home directory:
+
+```json
+{
+  "extensions": {
+    "sourcegraph/open-in-vscode": true
+  },
+  "vscode.open.basePath": "//wsl$/Ubuntu-18.04/home",
+  "vscode.open.uncPath": true
+}
+```

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
           "type": "string"
         },
         "vscode.open.uncPath": {
-          "description": "Set true to enable support for UNC path, which uses double slashes or backslashes to precede the name of the computer volume (as used in Windows or WSL).",
+          "description": "Set true to enable support for Universal naming convention (UNC) paths, which use double slashes or backslashes before the host device name (as used in Windows or WSL).",
           "type": "boolean"
         }
       }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
         "vscode.open.basePath": {
           "description": "The file path on the machine to the folder that is expected to contain all repositories.",
           "type": "string"
+        },
+        "vscode.open.uncPath": {
+          "description": "Set true to enable support for UNC path, which uses double slashes or backslashes to precede the name of the computer volume (as used in Windows or WSL).",
+          "type": "boolean"
         }
       }
     }

--- a/src/open-in-vscode.ts
+++ b/src/open-in-vscode.ts
@@ -6,6 +6,7 @@ function getOpenUrl(textDocumentUri: URL): URL {
     // TODO support different folder layouts, e.g. repo nested under owner name
     const repoBaseName = rawRepoName.split('/').pop()!
     const basePath: unknown = sourcegraph.configuration.get().value['vscode.open.basePath']
+    const isUNC: boolean = sourcegraph.configuration.get().value['vscode.open.uncPath']
     if (typeof basePath !== 'string') {
         throw new Error(
             `Setting \`vscode.open.basePath\` must be set in your [user settings](${new URL('/user/settings', sourcegraph.internal.sourcegraphURL.href).href}) to open files in VS Code.`
@@ -19,9 +20,9 @@ function getOpenUrl(textDocumentUri: URL): URL {
     const relativePath = decodeURIComponent(textDocumentUri.hash.slice('#'.length))
     const absolutePath = path.join(basePath, repoBaseName, relativePath)
 
-    // if windows add an extra slash in the beginning
+    // if windows or enabled UNC path, add an extra slash in the beginning
     let uri = '';
-    if (/^[a-zA-Z]:\\/.test(basePath)) {
+    if (/^[a-zA-Z]:\\/.test(basePath) || isUNC) {
         uri = 'vscode://file/' + absolutePath
     } else {
         uri = 'vscode://file' + absolutePath


### PR DESCRIPTION
This is a PR to add support for UNC path.

By enabling the uncPath option, an additional `/` will be added in front of the basePath to emulate the UNC paths format that works on Windows and WSL.
```json
{
  "extensions": {
    "sourcegraph/open-in-vscode": true
  },
  "vscode.open.basePath": "//$wsl/Ubuntu-18.04/home",
  "vscode.open.uncPath": true
}
// will open file with vscode://file//$wsl/Ubuntu-18.04/home/sourcegraph-open-in-vscode/src/open-in-vscode.ts
```
![image](https://user-images.githubusercontent.com/68532117/125470032-c982e97a-79fe-4dfe-a075-103341d7223e.png)

vs. `vscode://file/$wsl/Ubuntu-18.04/home/sourcegraph-open-in-vscode/src/open-in-vscode.ts` without the uncPath enabled.

I believe this should resolve the issue detailed in https://github.com/sourcegraph/sourcegraph/issues/22776 